### PR TITLE
docs: uri-restriction directly returns if there is no route configs

### DIFF
--- a/example/rider_user_guide.md
+++ b/example/rider_user_guide.md
@@ -104,9 +104,8 @@ function uriRestrictionHandler:on_request_header()
         return
     end
 
-    -- 配置未定义报错
+    -- Configuring to nil defines that the route configuration does not exist (route plugin is not configured)
     if config == nil then
-        envoy.logErr('no route config!')
         return
     end
 

--- a/example/rider_user_guide.zh_CN.md
+++ b/example/rider_user_guide.zh_CN.md
@@ -104,9 +104,8 @@ function uriRestrictionHandler:on_request_header()
         return
     end
 
-    -- 配置未定义报错
+    -- 配置为nil定义代表路由级别配置不存在（未配置路由级插件）
     if config == nil then
-        envoy.logErr('no route config!')
         return
     end
 


### PR DESCRIPTION
**Description**

Delete the error log and make uri-restriction plugin directly return if there is no route configs

**Affects**

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Test and Release
- [ ] User Experience
